### PR TITLE
Make noise core

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,30 @@ impl<R: NoiseResultContext, W: NoiseWeightsSettings, N: NoiseOperation<R, W::Wei
             frequency,
         }
     }
+
+    /// Sets the [`seed`](Self::seed) of the [`Noise`] as a `u64`.
+    pub fn set_seed(&mut self, seed: u64) {
+        self.seed = RngContext::from_bits(seed);
+    }
+
+    /// Gets the [`seed`](Self::seed) of the [`Noise`] as a `u64`.
+    pub fn get_seed(&mut self) -> u64 {
+        self.seed.to_bits()
+    }
+
+    /// Sets the [`frequency`](Self::frequency) of the [`Noise`] via its inverse/period.
+    /// It is often more convenient to reason about the scale of noise via its period rather than its frequency,
+    /// but it is stored as a frequency for efficiency.
+    pub fn set_period(&mut self, period: f32) {
+        self.frequency = 1.0 / period;
+    }
+
+    /// Gets the [`frequency`](Self::frequency) of the [`Noise`] via its inverse/period.
+    /// It is often more convenient to reason about the scale of noise via its period rather than its frequency,
+    /// but it is stored as a frequency for efficiency.
+    pub fn get_period(&mut self) -> f32 {
+        1.0 / self.frequency
+    }
 }
 
 /// Indicates that this noise is samplable by type `I`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,3 +239,52 @@ impl<
         self.sample_for(loc)
     }
 }
+
+macro_rules! impl_all_operation_tuples {
+    () => { };
+
+    ($i:ident=$f:tt, $($ni:ident=$nf:tt),* $(,)?) => {
+        impl<R: NoiseResultContext, W: NoiseWeights, $i: NoiseOperation<R, W>, $($ni: NoiseOperation<R, W>),* > NoiseOperation<R, W> for ($i, $($ni),*) {
+            #[inline]
+            fn prepare(&self, result_context: &mut R, weights: &mut W) {
+                self.$f.prepare(result_context, weights);
+                $(self.$nf.prepare(result_context, weights);)*
+            }
+        }
+
+        impl<I: VectorSpace, R: NoiseResultContext, W: NoiseWeights, $i: NoiseOperationFor<I, R, W>, $($ni: NoiseOperationFor<I, R, W>),* > NoiseOperationFor<I, R, W> for ($i, $($ni),*) {
+            #[inline]
+            fn do_noise_op(
+                &self,
+                seeds: &mut RngContext,
+                working_loc: &mut I,
+                result: &mut R::Result,
+                weights: &mut W,
+            ) {
+                self.$f.do_noise_op(seeds, working_loc, result, weights);
+                $(self.$nf.do_noise_op(seeds, working_loc, result, weights);)*
+            }
+        }
+
+        impl_all_operation_tuples!($($ni=$nf,)*);
+    };
+}
+
+impl_all_operation_tuples!(
+    T15 = 15,
+    T14 = 14,
+    T13 = 13,
+    T12 = 12,
+    T11 = 11,
+    T10 = 10,
+    T9 = 9,
+    T8 = 8,
+    T7 = 7,
+    T6 = 6,
+    T5 = 5,
+    T4 = 4,
+    T3 = 3,
+    T2 = 2,
+    T1 = 1,
+    T0 = 0,
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,73 @@
 )]
 #![doc = include_str!("../README.md")]
 
+use rng::RngContext;
+
 #[cfg(test)]
 extern crate alloc;
 
 pub mod rng;
+
+/// This represents the context of some [`NoiseResult`].
+pub trait NoiseResultContext {
+    /// This is the type that actually computes the result based on this context.
+    type Result: NoiseResult;
+
+    /// Informs the context that this much weight is expected.
+    /// This allows precomputing the total weight.
+    fn expect_weight(&mut self, weight: f32);
+
+    /// Based on this context, creates a result that can start accumulating noise operations.
+    fn start_result(&self) -> Self::Result;
+}
+
+/// Represents a working result of a noise sample.
+pub trait NoiseResult {
+    /// Informs the result that `weight` will be in included even though it was not in [`NoiseResultContext::expect_weight`].
+    fn add_unexpected_weight_to_total(&mut self, weight: f32);
+}
+
+/// Signifies that the [`NoiseResult`] can finalize into type `T`.
+pub trait NoiseResultOf<T>: NoiseResult {
+    /// Collapses all accumulated noise results into a finished product `T`.
+    fn finish(self) -> T;
+}
+
+/// Specifies that this [`NoiseResult`] can include values of type `V`.
+pub trait NoiseResultFor<V>: NoiseResult {
+    /// Includes `value` in the final result at this `weight`.
+    /// The `value` should be kepy plain, for example, if multiplication is needed, this will do so.
+    /// If `weight` was not included in [`NoiseResultContext::expect_weight`],
+    /// be sure to also call [`add_unexpected_weight_to_total`](NoiseResult::add_unexpected_weight_to_total).
+    fn include_value(&mut self, value: V, weight: f32);
+}
+
+/// Specifies that this generates configurable weights for different layers of noise.
+pub trait NoiseWeights {
+    /// Generates the weight of the next layer of noise.
+    fn next_weight(&mut self) -> f32;
+}
+
+/// An operation that contributes to some noise result.
+/// `I` represents input. `R` represents how the result is collected. `W` represents how each layer is weighted.
+pub trait NoiseOperation<I, R: NoiseResultContext, W: NoiseWeights> {
+    /// Prepares the result context `R` for this noise. This is like a dry run of the noise to try to precompute anything it needs.
+    fn prepare(&self, seeds: &mut RngContext, result: &mut R, weights: &mut W);
+
+    /// Performs the noise operation. Use `seeds` to drive randomness, `working_loc` to drive input, `result` to collect output, and `weight` to enable blending with other operations.
+    fn do_noise_op(
+        &self,
+        seeds: &mut RngContext,
+        working_loc: &mut I,
+        result: &mut R::Result,
+        weights: &mut W,
+    );
+}
+
+/// Represents a noise function based on layers of [`NoiseOperation`]s.
+pub struct Noise<R, W, N> {
+    result_context: R,
+    weights: W,
+    seed: RngContext,
+    noise: N,
+}


### PR DESCRIPTION
Added all the core `Noise` and `Sampleable` items. I chose to make all inputs `VectorSpace` out of convenience. It makes `f64` types impossible for now, but that's not a huge deal, and there's already some discussion of opening `VectorSpace` up to f64 types.