### PR TITLE
Builder patter for noise

### DIFF
--- a/examples/show_noise.rs
+++ b/examples/show_noise.rs
@@ -10,24 +10,16 @@ use bevy::{
     render::render_resource::{Extent3d, TextureDimension, TextureFormat},
 };
 use noiz::{
-    DynamicConfigurableSampleable, Noise,
     cell_noise::{
         BlendCellGradients, BlendCellValues, DistanceBlend, DistanceToEdge, MixCellGradients,
         MixCellValues, MixCellValuesForDomain, PerCell, PerCellPointDistances, PerNearestPoint,
         QualityGradients, QuickGradients, SimplecticBlend, WorleyAverage, WorleyDifference,
         WorleyLeastDistance, WorleyProduct, WorleyRatio, WorleySecondLeastDistance,
         WorleySmoothMin,
-    },
-    cells::{OrthoGrid, SimplexGrid, Voronoi},
-    curves::{CubicSMin, DoubleSmoothstep, Linear, Smoothstep},
-    layering::{
+    }, cells::{OrthoGrid, SimplexGrid, Voronoi}, curves::{CubicSMin, DoubleSmoothstep, Linear, Smoothstep}, layering::{
         DomainWarp, FractalLayers, LayeredNoise, Normed, NormedByDerivative, Octave,
         PeakDerivativeContribution, Persistence, PersistenceConfig, SmoothDerivativeContribution,
-    },
-    lengths::{ChebyshevLength, EuclideanLength, ManhattanLength},
-    math_noise::{Billow, PingPong, Pow4, SNormToUNorm, Spiral},
-    misc_noise::{Offset, Peeled, RandomElements, SelfMasked},
-    rng::{Random, SNorm, UNorm},
+    }, lengths::{ChebyshevLength, EuclideanLength, ManhattanLength}, math_noise::{Billow, PingPong, Pow4, SNormToUNorm, Spiral}, misc_noise::{Offset, Peeled, RandomElements, SelfMasked}, prelude::{common_noise::SimplexWithDerivative, LayeredBuilder, NoiseBuilder}, rng::{Random, SNorm, UNorm}, DynamicConfigurableSampleable, Noise
 };
 
 fn main() -> AppExit {
@@ -633,38 +625,16 @@ fn main() -> AppExit {
                         },
                         NoiseOption {
                             name: "Derivative Fractal Simplex noise",
-                            noise: Box::new(Noise::<(
-                                LayeredNoise<
-                                    NormedByDerivative<
-                                        f32,
-                                        EuclideanLength,
-                                        PeakDerivativeContribution,
-                                    >,
-                                    Persistence,
-                                    FractalLayers<
-                                        Octave<
-                                            BlendCellGradients<
-                                                SimplexGrid,
-                                                SimplecticBlend,
-                                                QuickGradients,
-                                                true,
-                                            >,
-                                        >,
-                                    >,
-                                >,
-                                SNormToUNorm,
-                            )>::from((
-                                LayeredNoise::new(
-                                    NormedByDerivative::default(),
-                                    Persistence(0.6),
-                                    FractalLayers {
-                                        layer: Default::default(),
-                                        lacunarity: 1.8,
-                                        amount: 8,
-                                    },
-                                ),
-                                Default::default(),
-                            ))),
+                            noise: Box::new(
+                                NoiseBuilder::new()
+                                    .chain(
+                                        LayeredBuilder::normed_by_peak_derivative(0.6)
+                                            .fractal(SimplexWithDerivative::default(), 1.8, 8)
+                                            .get_noise_fn(),
+                                    )
+                                    .unorm()
+                                    .get_noise_default(),
+                            ),
                         },
                         NoiseOption {
                             name: "Domain Mapping White",

--- a/examples/show_noise.rs
+++ b/examples/show_noise.rs
@@ -636,13 +636,20 @@ fn main() -> AppExit {
                             name: "Derivative Fractal Simplex noise",
                             noise: Box::new(
                                 NoiseBuilder::new(())
-                                    .layered(0.6, |b| {
-                                        b.fractal_with(1.8, 8, |b| {
-                                            b.octave(SimplexWithDerivative::default())
-                                        })
-                                        .normed_by_peak_derivative()
-                                    })
-                                    .unorm()
+                                    .layered(
+                                        NormedByDerivative::<
+                                            f32,
+                                            EuclideanLength,
+                                            PeakDerivativeContribution,
+                                        >::default(),
+                                        Persistence(0.6),
+                                        |lbuilder| {
+                                            lbuilder.fractal_with(1.8, 8, |fbuilder| {
+                                                fbuilder.octave(SimplexWithDerivative::default())
+                                            })
+                                        },
+                                    )
+                                    .chain(SNormToUNorm)
                                     .get_noise_default(),
                             ),
                         },

--- a/examples/show_noise.rs
+++ b/examples/show_noise.rs
@@ -10,16 +10,25 @@ use bevy::{
     render::render_resource::{Extent3d, TextureDimension, TextureFormat},
 };
 use noiz::{
+    DynamicConfigurableSampleable, Noise,
     cell_noise::{
         BlendCellGradients, BlendCellValues, DistanceBlend, DistanceToEdge, MixCellGradients,
         MixCellValues, MixCellValuesForDomain, PerCell, PerCellPointDistances, PerNearestPoint,
         QualityGradients, QuickGradients, SimplecticBlend, WorleyAverage, WorleyDifference,
         WorleyLeastDistance, WorleyProduct, WorleyRatio, WorleySecondLeastDistance,
         WorleySmoothMin,
-    }, cells::{OrthoGrid, SimplexGrid, Voronoi}, curves::{CubicSMin, DoubleSmoothstep, Linear, Smoothstep}, layering::{
+    },
+    cells::{OrthoGrid, SimplexGrid, Voronoi},
+    curves::{CubicSMin, DoubleSmoothstep, Linear, Smoothstep},
+    layering::{
         DomainWarp, FractalLayers, LayeredNoise, Normed, NormedByDerivative, Octave,
         PeakDerivativeContribution, Persistence, PersistenceConfig, SmoothDerivativeContribution,
-    }, lengths::{ChebyshevLength, EuclideanLength, ManhattanLength}, math_noise::{Billow, PingPong, Pow4, SNormToUNorm, Spiral}, misc_noise::{Offset, Peeled, RandomElements, SelfMasked}, prelude::{common_noise::SimplexWithDerivative, LayeredBuilder, NoiseBuilder}, rng::{Random, SNorm, UNorm}, DynamicConfigurableSampleable, Noise
+    },
+    lengths::{ChebyshevLength, EuclideanLength, ManhattanLength},
+    math_noise::{Billow, PingPong, Pow4, SNormToUNorm, Spiral},
+    misc_noise::{Offset, Peeled, RandomElements, SelfMasked},
+    prelude::{NoiseBuilder, common_noise::SimplexWithDerivative},
+    rng::{Random, SNorm, UNorm},
 };
 
 fn main() -> AppExit {
@@ -626,12 +635,13 @@ fn main() -> AppExit {
                         NoiseOption {
                             name: "Derivative Fractal Simplex noise",
                             noise: Box::new(
-                                NoiseBuilder::new()
-                                    .chain(
-                                        LayeredBuilder::normed_by_peak_derivative(0.6)
-                                            .fractal(SimplexWithDerivative::default(), 1.8, 8)
-                                            .get_noise_fn(),
-                                    )
+                                NoiseBuilder::new(())
+                                    .layered(0.6, |b| {
+                                        b.fractal_with(1.8, 8, |b| {
+                                            b.octave(SimplexWithDerivative::default())
+                                        })
+                                        .normed_by_peak_derivative()
+                                    })
                                     .unorm()
                                     .get_noise_default(),
                             ),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,338 @@
+//! Contains a builder pattern API for building noise
+//! It is optional, but may provide a better experience.
+
+use crate::{
+    Masked, Noise, SNormToUNorm, Scaled, UNormToSNorm,
+    layering::{LayerOperation, LayerResultContext, LayerWeightsSettings},
+    lengths::EuclideanLength,
+    prelude::{
+        DomainWarp, FractalLayers, LayeredNoise, Normed, NormedByDerivative, Octave,
+        PeakDerivativeContribution, Persistence,
+    },
+    rng::NoiseRng,
+};
+
+///Enables "chaining" tuples together, like an append function.
+pub trait TupleChainable<T> {
+    ///The output type
+    type ChainOutput;
+    ///Actually chain the elements
+    fn chain(self, next: T) -> Self::ChainOutput;
+}
+
+///Unnest a single element tuple, leave other tuples untouched
+pub trait Unnest {
+    ///The output type
+    type UnnestOutput;
+
+    ///Remove the nesting
+    fn unnest(self) -> Self::UnnestOutput;
+}
+
+macro_rules! impl_chain_tuple {
+    ($($t:ident-$i:tt),*) => {
+        impl<$($t,)* Tn> TupleChainable<Tn> for ($($t,)*)
+        {
+            type ChainOutput = ($($t,)* Tn);
+
+            #[inline]
+            fn chain(self, next: Tn) -> Self::ChainOutput {
+                ($(self.$i,)* next)
+            }
+        }
+    };
+}
+
+#[rustfmt::skip]
+mod chain_impls {
+    use super::*;
+    impl_chain_tuple!(T0-0);
+    impl_chain_tuple!(T0-0, T1-1);
+    impl_chain_tuple!(T0-0, T1-1, T2-2);
+    impl_chain_tuple!(T0-0, T1-1, T2-2, T3-3);
+    impl_chain_tuple!(T0-0, T1-1, T2-2, T3-3, T4-4);
+    impl_chain_tuple!(T0-0, T1-1, T2-2, T3-3, T4-4, T5-5);
+    impl_chain_tuple!(T0-0, T1-1, T2-2, T3-3, T4-4, T5-5, T6-6);
+    impl_chain_tuple!(T0-0, T1-1, T2-2, T3-3, T4-4, T5-5, T6-6, T7-7);
+    impl_chain_tuple!(T0-0, T1-1, T2-2, T3-3, T4-4, T5-5, T6-6, T7-7, T8-8);
+    impl_chain_tuple!(T0-0, T1-1, T2-2, T3-3, T4-4, T5-5, T6-6, T7-7, T8-8, T9-9);
+    impl_chain_tuple!(T0-0, T1-1, T2-2, T3-3, T4-4, T5-5, T6-6, T7-7, T8-8, T9-9, T10-10);
+    impl_chain_tuple!(T0-0, T1-1, T2-2, T3-3, T4-4, T5-5, T6-6, T7-7, T8-8, T9-9, T10-10, T11-11);
+    impl_chain_tuple!(T0-0, T1-1, T2-2, T3-3, T4-4, T5-5, T6-6, T7-7, T8-8, T9-9, T10-10, T11-11, T12-12);
+    impl_chain_tuple!(T0-0, T1-1, T2-2, T3-3, T4-4, T5-5, T6-6, T7-7, T8-8, T9-9, T10-10, T11-11, T12-12, T13-13);
+    impl_chain_tuple!(T0-0, T1-1, T2-2, T3-3, T4-4, T5-5, T6-6, T7-7, T8-8, T9-9, T10-10, T11-11, T12-12, T13-13, T14-14);
+}
+
+impl<T2> TupleChainable<T2> for () {
+    type ChainOutput = (T2,);
+    fn chain(self, next: T2) -> Self::ChainOutput {
+        (next,)
+    }
+}
+
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> TupleChainable<T16>
+    for (
+        T0,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+    )
+{
+    type ChainOutput = (Self, T16);
+    fn chain(self, next: T16) -> Self::ChainOutput {
+        (self, next)
+    }
+}
+
+impl Unnest for () {
+    type UnnestOutput = ();
+    #[inline]
+    fn unnest(self) -> Self::UnnestOutput {
+        ()
+    }
+}
+
+impl<T> Unnest for (T,) {
+    type UnnestOutput = T;
+    #[inline]
+    fn unnest(self) -> Self::UnnestOutput {
+        self.0
+    }
+}
+
+macro_rules! impl_unnest {
+    ($($t:ident),*) => {
+        impl<$($t,)*> Unnest for ($($t,)*)
+        {
+            type UnnestOutput = ($($t,)*);
+
+            #[inline]
+            fn unnest(self) -> Self::UnnestOutput {
+                self
+            }
+        }
+    };
+}
+
+#[rustfmt::skip]
+mod unnest_impls {
+    use super::*;
+    impl_unnest!(T0, T1);
+    impl_unnest!(T0, T1, T2);
+    impl_unnest!(T0, T1, T2, T3);
+    impl_unnest!(T0, T1, T2, T3, T4);
+    impl_unnest!(T0, T1, T2, T3, T4, T5);
+    impl_unnest!(T0, T1, T2, T3, T4, T5, T6);
+    impl_unnest!(T0, T1, T2, T3, T4, T5, T6, T7);
+    impl_unnest!(T0, T1, T2, T3, T4, T5, T6, T7, T8);
+    impl_unnest!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9);
+    impl_unnest!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
+    impl_unnest!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
+    impl_unnest!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
+    impl_unnest!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
+    impl_unnest!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
+}
+
+/// A builder struct for noises
+pub struct NoiseBuilder<T>(T);
+
+impl NoiseBuilder<()> {
+    ///Create new builder
+    pub fn new() -> Self {
+        Self(())
+    }
+}
+
+impl<T1> NoiseBuilder<T1> {
+    ///Chain the noise with another
+    pub fn chain<T2>(self, other: T2) -> NoiseBuilder<T1::ChainOutput>
+    where
+        T1: TupleChainable<T2>,
+    {
+        NoiseBuilder(self.0.chain(other))
+    }
+    ///Chain with default value
+    pub fn chain_default<T2: Default>(self) -> NoiseBuilder<T1::ChainOutput>
+    where
+        T1: TupleChainable<T2>,
+    {
+        NoiseBuilder(self.0.chain(T2::default()))
+    }
+    ///Mask the noise with another
+    pub fn mask<T2>(self, other: T2) -> NoiseBuilder<(Masked<T1::UnnestOutput, T2>,)>
+    where
+        T1: Unnest,
+    {
+        NoiseBuilder((Masked(self.0.unnest(), other),))
+    }
+
+    ///Scale the noise
+    pub fn scale<T>(self, scale: T) -> NoiseBuilder<T1::ChainOutput>
+    where
+        T1: TupleChainable<Scaled<T>>,
+    {
+        self.chain(Scaled::<T>(scale))
+    }
+
+    ///Swap to unorm for this noise
+    pub fn unorm(self) -> NoiseBuilder<T1::ChainOutput>
+    where
+        T1: TupleChainable<SNormToUNorm>,
+    {
+        self.chain(SNormToUNorm::default())
+    }
+
+    ///Swap to snorm for this noise
+    pub fn snorm(self) -> NoiseBuilder<T1::ChainOutput>
+    where
+        T1: TupleChainable<UNormToSNorm>,
+    {
+        self.chain(UNormToSNorm::default())
+    }
+
+    ///Create a noise for the builder
+    pub fn get_noise(self, seed: u32, frequency: f32) -> Noise<T1::UnnestOutput>
+    where
+        T1: Unnest,
+    {
+        Noise {
+            noise: self.0.unnest(),
+            seed: NoiseRng(seed),
+            frequency,
+        }
+    }
+
+    ///Create a noise for the builder
+    pub fn get_noise_default(self) -> Noise<T1::UnnestOutput>
+    where
+        T1: Unnest,
+    {
+        Noise::from(self.0.unnest())
+    }
+    ///Get the underlying noise function
+    pub fn get_noise_fn(self) -> T1::UnnestOutput
+    where
+        T1: Unnest,
+    {
+        self.0.unnest()
+    }
+}
+
+///A builder struct for layered noise
+pub struct LayeredBuilder<R, W, N> {
+    result_settings: R,
+    weight_settings: W,
+    noise: N,
+}
+
+impl<R: LayerResultContext, W: LayerWeightsSettings> LayeredBuilder<R, W, ()> {
+    /// Constructs a [`LayeredBuilder`] from this [`LayerResultContext`], [`LayerWeightsSettings`], and an empty noise.
+    pub fn new(result_settings: R, weight_settings: W) -> Self {
+        Self {
+            result_settings,
+
+            weight_settings,
+
+            noise: (),
+        }
+    }
+}
+
+impl
+    LayeredBuilder<
+        NormedByDerivative<f32, EuclideanLength, PeakDerivativeContribution>,
+        Persistence,
+        (),
+    >
+{
+    /// Constructs a [`LayeredBuilder`] from for the a layered noise with given persitence,
+    ///  and normed by derivative with the associated derivative contribution
+    pub fn normed_by_peak_derivative(persistence: f32) -> Self {
+        LayeredBuilder {
+            result_settings: NormedByDerivative::default(),
+            weight_settings: Persistence(persistence),
+            noise: (),
+        }
+    }
+}
+
+impl LayeredBuilder<Normed<f32>, Persistence, ()> {
+    /// Constructs a [`LayeredBuilder`] from for the a layered noise with given persitence,
+    ///  and normed by derivative with the associated derivative contribution
+    pub fn normed(persistence: f32) -> Self {
+        LayeredBuilder {
+            result_settings: Normed::default(),
+            weight_settings: Persistence(persistence),
+            noise: (),
+        }
+    }
+}
+
+impl<R: LayerResultContext, W: LayerWeightsSettings, N> LayeredBuilder<R, W, N> {
+    /// Adds a simple octave layer to the layered noise
+    pub fn octave<N2>(self, octave: N2) -> LayeredBuilder<R, W, N::ChainOutput>
+    where
+        N: TupleChainable<Octave<N2>>,
+    {
+        LayeredBuilder {
+            result_settings: self.result_settings,
+            weight_settings: self.weight_settings,
+            noise: self.noise.chain(Octave(octave)),
+        }
+    }
+    /// Adds a fractal layer to the layered noise
+    pub fn fractal<N2>(
+        self,
+        noise: N2,
+        lacunarity: f32,
+        amount: u32,
+    ) -> LayeredBuilder<R, W, N::ChainOutput>
+    where
+        N: TupleChainable<FractalLayers<Octave<N2>>>,
+    {
+        LayeredBuilder {
+            result_settings: self.result_settings,
+            weight_settings: self.weight_settings,
+            noise: self.noise.chain(FractalLayers {
+                layer: Octave(noise),
+                lacunarity,
+                amount,
+            }),
+        }
+    }
+    ///Adds a domain warping layer
+    pub fn warp<T>(self, warper: T, strength: f32) -> LayeredBuilder<R, W, N::ChainOutput>
+    where
+        N: TupleChainable<DomainWarp<T>>,
+    {
+        LayeredBuilder {
+            result_settings: self.result_settings,
+            weight_settings: self.weight_settings,
+            noise: self.noise.chain(DomainWarp { warper, strength }),
+        }
+    }
+    ///Creates the underlying Noise Function
+    pub fn get_noise_fn(self) -> LayeredNoise<R, W, N::UnnestOutput>
+    where
+        N: Unnest,
+        N::UnnestOutput: LayerOperation<R, W::Weights>,
+    {
+        LayeredNoise::new(
+            self.result_settings,
+            self.weight_settings,
+            self.noise.unnest(),
+        )
+    }
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -99,9 +99,7 @@ impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> 
 impl Unnest for () {
     type UnnestOutput = ();
     #[inline]
-    fn unnest(self) -> Self::UnnestOutput {
-        ()
-    }
+    fn unnest(self) -> Self::UnnestOutput {}
 }
 
 impl<T> Unnest for (T,) {
@@ -144,33 +142,38 @@ mod unnest_impls {
     impl_unnest!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
     impl_unnest!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
 }
-
-/// A builder struct for noises
+/// A builder struct for noise.
+/// It provides a more streamlined API that the manual setup.
+///
+/// All the methods on [`NoiseBuilder`] consume the object, and return a new [`NoiseBuilder`], with a new type.
+/// As it is entierly typed, it produces exactly the same [`Noise`] as a manual setup, with the same performance.
+///
+/// All types should be inferred from the parameters.
+///
+/// The final [`Noise`] can be retrieved with [`NoiseBuilder::get_noise`] or [`NoiseBuilder::get_noise_default`]
 pub struct NoiseBuilder<T>(T);
 
-impl NoiseBuilder<()> {
-    ///Create new builder
-    pub fn new() -> Self {
-        Self(())
+impl<T> NoiseBuilder<(T,)> {
+    /// Creates a [`NoiseBuilder`] with the given noise function.
+    /// The builder API can then be used to modify the noise.
+    pub fn new(noise: T) -> Self {
+        Self((noise,))
     }
 }
 
 impl<T1> NoiseBuilder<T1> {
-    ///Chain the noise with another
+    /// Chain the inner noise with the given noise function `other`.
+    /// If the inner noise is already a tuple, then `other` will be added at the end of the tuple,
+    /// with no additional nesting.
     pub fn chain<T2>(self, other: T2) -> NoiseBuilder<T1::ChainOutput>
     where
         T1: TupleChainable<T2>,
     {
         NoiseBuilder(self.0.chain(other))
     }
-    ///Chain with default value
-    pub fn chain_default<T2: Default>(self) -> NoiseBuilder<T1::ChainOutput>
-    where
-        T1: TupleChainable<T2>,
-    {
-        NoiseBuilder(self.0.chain(T2::default()))
-    }
-    ///Mask the noise with another
+
+    /// Mask the noise with the given noise function `other`.
+    /// Both noise will be sampled at the same point and multiplied together.
     pub fn mask<T2>(self, other: T2) -> NoiseBuilder<(Masked<T1::UnnestOutput, T2>,)>
     where
         T1: Unnest,
@@ -178,7 +181,8 @@ impl<T1> NoiseBuilder<T1> {
         NoiseBuilder((Masked(self.0.unnest(), other),))
     }
 
-    ///Scale the noise
+    /// Scale the noise
+    /// It is a shortcut for `self.chain(Scaled(scale))`
     pub fn scale<T>(self, scale: T) -> NoiseBuilder<T1::ChainOutput>
     where
         T1: TupleChainable<Scaled<T>>,
@@ -187,22 +191,25 @@ impl<T1> NoiseBuilder<T1> {
     }
 
     ///Swap to unorm for this noise
+    /// It is a shortcut for `self.chain(SNormToUNorm)`
     pub fn unorm(self) -> NoiseBuilder<T1::ChainOutput>
     where
         T1: TupleChainable<SNormToUNorm>,
     {
-        self.chain(SNormToUNorm::default())
+        self.chain(SNormToUNorm)
     }
 
     ///Swap to snorm for this noise
+    /// It is a shortcut for `self.chain(UNormToSNorm)`
     pub fn snorm(self) -> NoiseBuilder<T1::ChainOutput>
     where
         T1: TupleChainable<UNormToSNorm>,
     {
-        self.chain(UNormToSNorm::default())
+        self.chain(UNormToSNorm)
     }
 
-    ///Create a noise for the builder
+    /// Create a [`Noise`] for the builder, with the given seed and frequency.
+    /// This produces a fully typed object, that can no longer be modified.
     pub fn get_noise(self, seed: u32, frequency: f32) -> Noise<T1::UnnestOutput>
     where
         T1: Unnest,
@@ -214,23 +221,54 @@ impl<T1> NoiseBuilder<T1> {
         }
     }
 
-    ///Create a noise for the builder
+    /// Create a [`Noise`] for the builder, with the default seed and frequency.
+    /// This produces a fully typed object, that can no longer be modified.
     pub fn get_noise_default(self) -> Noise<T1::UnnestOutput>
     where
         T1: Unnest,
     {
         Noise::from(self.0.unnest())
     }
-    ///Get the underlying noise function
+
+    /// Get the underlying noise function
+    /// Generally not needed, unless you need to mix the builder API with other functions.
     pub fn get_noise_fn(self) -> T1::UnnestOutput
     where
         T1: Unnest,
     {
         self.0.unnest()
     }
+
+    /// Chain the inner noise with a layered noise, with the given persistence between layers.
+    /// It takes a closure that provides a [`LayeredBuilder`], which has the builder methods to build a layered noise.
+    /// The layered noise default to Normed layers with a Persistence, but that can be changed inside the builder.
+    pub fn layered<
+        N2,
+        R: LayerResultContext,
+        W: LayerWeightsSettings,
+        F: FnOnce(LayeredBuilder<Normed<f32>, Persistence, ()>) -> LayeredBuilder<R, W, N2>,
+    >(
+        self,
+        persistence: f32,
+        builder: F,
+    ) -> NoiseBuilder<T1::ChainOutput>
+    where
+        N2: Unnest,
+        N2::UnnestOutput: LayerOperation<R, W::Weights>,
+        T1: TupleChainable<LayeredNoise<R, W, N2::UnnestOutput>>,
+    {
+        self.chain(
+            builder(LayeredBuilder::new(
+                Normed::default(),
+                Persistence(persistence),
+            ))
+            .get_noise_fn(),
+        )
+    }
 }
 
-///A builder struct for layered noise
+/// A builder struct for layered noise
+/// Just as the [`NoiseBuilder`], it is fully typed and all methods consume it and return a new object.
 pub struct LayeredBuilder<R, W, N> {
     result_settings: R,
     weight_settings: W,
@@ -239,7 +277,7 @@ pub struct LayeredBuilder<R, W, N> {
 
 impl<R: LayerResultContext, W: LayerWeightsSettings> LayeredBuilder<R, W, ()> {
     /// Constructs a [`LayeredBuilder`] from this [`LayerResultContext`], [`LayerWeightsSettings`], and an empty noise.
-    pub fn new(result_settings: R, weight_settings: W) -> Self {
+    fn new(result_settings: R, weight_settings: W) -> Self {
         Self {
             result_settings,
 
@@ -250,38 +288,46 @@ impl<R: LayerResultContext, W: LayerWeightsSettings> LayeredBuilder<R, W, ()> {
     }
 }
 
-impl
-    LayeredBuilder<
-        NormedByDerivative<f32, EuclideanLength, PeakDerivativeContribution>,
-        Persistence,
-        (),
-    >
-{
-    /// Constructs a [`LayeredBuilder`] from for the a layered noise with given persitence,
-    ///  and normed by derivative with the associated derivative contribution
-    pub fn normed_by_peak_derivative(persistence: f32) -> Self {
+impl<R: LayerResultContext, W: LayerWeightsSettings, N> LayeredBuilder<R, W, N> {
+    /// Transform the LayeredNoise to use normed by peak derivative.
+    pub fn normed_by_peak_derivative(
+        self,
+    ) -> LayeredBuilder<NormedByDerivative<f32, EuclideanLength, PeakDerivativeContribution>, W, N>
+    {
         LayeredBuilder {
             result_settings: NormedByDerivative::default(),
-            weight_settings: Persistence(persistence),
-            noise: (),
+            weight_settings: self.weight_settings,
+            noise: self.noise,
         }
     }
-}
 
-impl LayeredBuilder<Normed<f32>, Persistence, ()> {
-    /// Constructs a [`LayeredBuilder`] from for the a layered noise with given persitence,
-    ///  and normed by derivative with the associated derivative contribution
-    pub fn normed(persistence: f32) -> Self {
+    /// Transform the LayeredNoise to used normed (the default).
+    pub fn normed(self) -> LayeredBuilder<Normed<f32>, W, N> {
         LayeredBuilder {
             result_settings: Normed::default(),
-            weight_settings: Persistence(persistence),
-            noise: (),
+            weight_settings: self.weight_settings,
+            noise: self.noise,
         }
     }
-}
 
-impl<R: LayerResultContext, W: LayerWeightsSettings, N> LayeredBuilder<R, W, N> {
+    /// Adds an octave layer to the layered noise
+    /// It takes a closure that provides a [`NoiseBuilder`] and expects a new one.
+    pub fn octave_with<N2: Unnest, F: FnOnce(NoiseBuilder<()>) -> NoiseBuilder<N2>>(
+        self,
+        f: F,
+    ) -> LayeredBuilder<R, W, N::ChainOutput>
+    where
+        N: TupleChainable<Octave<N2::UnnestOutput>>,
+    {
+        LayeredBuilder {
+            result_settings: self.result_settings,
+            weight_settings: self.weight_settings,
+            noise: self.noise.chain(Octave(f(NoiseBuilder(())).get_noise_fn())),
+        }
+    }
+
     /// Adds a simple octave layer to the layered noise
+    /// It takes a noise function as its only argument.
     pub fn octave<N2>(self, octave: N2) -> LayeredBuilder<R, W, N::ChainOutput>
     where
         N: TupleChainable<Octave<N2>>,
@@ -292,39 +338,33 @@ impl<R: LayerResultContext, W: LayerWeightsSettings, N> LayeredBuilder<R, W, N> 
             noise: self.noise.chain(Octave(octave)),
         }
     }
-    /// Adds a fractal layer to the layered noise
-    pub fn fractal<N2>(
+
+    /// Adds a fractal layer to the layered noise.
+    /// It takes a closure that provides a [`FractalBuilder`] and expects a new one.
+    pub fn fractal_with<N2, F: FnOnce(FractalBuilder<()>) -> FractalBuilder<N2>>(
         self,
-        noise: N2,
         lacunarity: f32,
         amount: u32,
+        f: F,
     ) -> LayeredBuilder<R, W, N::ChainOutput>
     where
-        N: TupleChainable<FractalLayers<Octave<N2>>>,
+        N: TupleChainable<FractalLayers<N2>>,
     {
         LayeredBuilder {
             result_settings: self.result_settings,
             weight_settings: self.weight_settings,
-            noise: self.noise.chain(FractalLayers {
-                layer: Octave(noise),
-                lacunarity,
-                amount,
-            }),
+            noise: self.noise.chain(
+                f(FractalBuilder {
+                    noise: (),
+                    lacunarity,
+                    amount,
+                })
+                .get_layer(),
+            ),
         }
     }
-    ///Adds a domain warping layer
-    pub fn warp<T>(self, warper: T, strength: f32) -> LayeredBuilder<R, W, N::ChainOutput>
-    where
-        N: TupleChainable<DomainWarp<T>>,
-    {
-        LayeredBuilder {
-            result_settings: self.result_settings,
-            weight_settings: self.weight_settings,
-            noise: self.noise.chain(DomainWarp { warper, strength }),
-        }
-    }
-    ///Creates the underlying Noise Function
-    pub fn get_noise_fn(self) -> LayeredNoise<R, W, N::UnnestOutput>
+
+    fn get_noise_fn(self) -> LayeredNoise<R, W, N::UnnestOutput>
     where
         N: Unnest,
         N::UnnestOutput: LayerOperation<R, W::Weights>,
@@ -334,5 +374,64 @@ impl<R: LayerResultContext, W: LayerWeightsSettings, N> LayeredBuilder<R, W, N> 
             self.weight_settings,
             self.noise.unnest(),
         )
+    }
+}
+
+/// Builder struct for fractal layers
+pub struct FractalBuilder<N> {
+    noise: N,
+    lacunarity: f32,
+    amount: u32,
+}
+
+impl<N> FractalBuilder<N> {
+    /// Adds a simple octave layer to the fractal layer
+    /// It takes a noise function as its only argument.
+    pub fn octave<N2>(self, octave: N2) -> FractalBuilder<N::ChainOutput>
+    where
+        N: TupleChainable<Octave<N2>>,
+    {
+        FractalBuilder {
+            lacunarity: self.lacunarity,
+            amount: self.amount,
+            noise: self.noise.chain(Octave(octave)),
+        }
+    }
+
+    /// Adds an octave layer to the fractal layer
+    /// It takes a closure that provides a [`NoiseBuilder`] and expects a new one.
+    pub fn octave_with<N2: Unnest, F: FnOnce(NoiseBuilder<()>) -> NoiseBuilder<N2>>(
+        self,
+        f: F,
+    ) -> FractalBuilder<N::ChainOutput>
+    where
+        N: TupleChainable<Octave<N2::UnnestOutput>>,
+    {
+        FractalBuilder {
+            lacunarity: self.lacunarity,
+            amount: self.amount,
+            noise: self.noise.chain(Octave(f(NoiseBuilder(())).get_noise_fn())),
+        }
+    }
+
+    /// Adds a domain warping layer to the fractal layer.
+    /// It will apply to all the following layers inside the fractal.
+    pub fn warp<T>(self, warper: T, strength: f32) -> FractalBuilder<N::ChainOutput>
+    where
+        N: TupleChainable<DomainWarp<T>>,
+    {
+        FractalBuilder {
+            lacunarity: self.lacunarity,
+            amount: self.amount,
+            noise: self.noise.chain(DomainWarp { warper, strength }),
+        }
+    }
+
+    fn get_layer(self) -> FractalLayers<N> {
+        FractalLayers {
+            layer: self.noise,
+            lacunarity: self.lacunarity,
+            amount: self.amount,
+        }
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,17 +2,14 @@
 //! It is optional, but may provide a better experience.
 
 use crate::{
-    Masked, Noise, SNormToUNorm, Scaled, UNormToSNorm,
+    Noise,
     layering::{LayerOperation, LayerResultContext, LayerWeightsSettings},
-    lengths::EuclideanLength,
-    prelude::{
-        DomainWarp, FractalLayers, LayeredNoise, Normed, NormedByDerivative, Octave,
-        PeakDerivativeContribution, Persistence,
-    },
+    prelude::{DomainWarp, FractalLayers, LayeredNoise, Masked, Octave},
     rng::NoiseRng,
 };
 
-///Enables "chaining" tuples together, like an append function.
+/// Enables "chaining" tuples together, like an append function.
+/// If a type is [`TupleChainable<T>`], that means it can be chained with a new element of type `T`
 pub trait TupleChainable<T> {
     ///The output type
     type ChainOutput;
@@ -70,6 +67,7 @@ impl<T2> TupleChainable<T2> for () {
     }
 }
 
+// If max length is exceeded, adds a level of nesting.
 impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> TupleChainable<T16>
     for (
         T0,
@@ -146,7 +144,7 @@ mod unnest_impls {
 /// It provides a more streamlined API that the manual setup.
 ///
 /// All the methods on [`NoiseBuilder`] consume the object, and return a new [`NoiseBuilder`], with a new type.
-/// As it is entierly typed, it produces exactly the same [`Noise`] as a manual setup, with the same performance.
+/// As it is entirely typed, it produces exactly the same [`Noise`] as a manual setup, with the same performance.
 ///
 /// All types should be inferred from the parameters.
 ///
@@ -181,33 +179,6 @@ impl<T1> NoiseBuilder<T1> {
         NoiseBuilder((Masked(self.0.unnest(), other),))
     }
 
-    /// Scale the noise
-    /// It is a shortcut for `self.chain(Scaled(scale))`
-    pub fn scale<T>(self, scale: T) -> NoiseBuilder<T1::ChainOutput>
-    where
-        T1: TupleChainable<Scaled<T>>,
-    {
-        self.chain(Scaled::<T>(scale))
-    }
-
-    ///Swap to unorm for this noise
-    /// It is a shortcut for `self.chain(SNormToUNorm)`
-    pub fn unorm(self) -> NoiseBuilder<T1::ChainOutput>
-    where
-        T1: TupleChainable<SNormToUNorm>,
-    {
-        self.chain(SNormToUNorm)
-    }
-
-    ///Swap to snorm for this noise
-    /// It is a shortcut for `self.chain(UNormToSNorm)`
-    pub fn snorm(self) -> NoiseBuilder<T1::ChainOutput>
-    where
-        T1: TupleChainable<UNormToSNorm>,
-    {
-        self.chain(UNormToSNorm)
-    }
-
     /// Create a [`Noise`] for the builder, with the given seed and frequency.
     /// This produces a fully typed object, that can no longer be modified.
     pub fn get_noise(self, seed: u32, frequency: f32) -> Noise<T1::UnnestOutput>
@@ -239,31 +210,26 @@ impl<T1> NoiseBuilder<T1> {
         self.0.unnest()
     }
 
-    /// Chain the inner noise with a layered noise, with the given persistence between layers.
+    /// Chain the inner noise with a layered noise, with the given settings.
     /// It takes a closure that provides a [`LayeredBuilder`], which has the builder methods to build a layered noise.
-    /// The layered noise default to Normed layers with a Persistence, but that can be changed inside the builder.
+    /// The layered noise takes a weight settings (e.g. [`Persistence`]) and a result settings (e.g. [`Normed<f32>`])
     pub fn layered<
         N2,
         R: LayerResultContext,
         W: LayerWeightsSettings,
-        F: FnOnce(LayeredBuilder<Normed<f32>, Persistence, ()>) -> LayeredBuilder<R, W, N2>,
+        F: FnOnce(LayeredBuilder<R, W, ()>) -> LayeredBuilder<R, W, N2>,
     >(
         self,
-        persistence: f32,
-        builder: F,
+        result_settings: R,
+        weight_settings: W,
+        f: F,
     ) -> NoiseBuilder<T1::ChainOutput>
     where
         N2: Unnest,
         N2::UnnestOutput: LayerOperation<R, W::Weights>,
         T1: TupleChainable<LayeredNoise<R, W, N2::UnnestOutput>>,
     {
-        self.chain(
-            builder(LayeredBuilder::new(
-                Normed::default(),
-                Persistence(persistence),
-            ))
-            .get_noise_fn(),
-        )
+        self.chain(f(LayeredBuilder::new(result_settings, weight_settings)).get_noise_fn())
     }
 }
 
@@ -289,27 +255,6 @@ impl<R: LayerResultContext, W: LayerWeightsSettings> LayeredBuilder<R, W, ()> {
 }
 
 impl<R: LayerResultContext, W: LayerWeightsSettings, N> LayeredBuilder<R, W, N> {
-    /// Transform the LayeredNoise to use normed by peak derivative.
-    pub fn normed_by_peak_derivative(
-        self,
-    ) -> LayeredBuilder<NormedByDerivative<f32, EuclideanLength, PeakDerivativeContribution>, W, N>
-    {
-        LayeredBuilder {
-            result_settings: NormedByDerivative::default(),
-            weight_settings: self.weight_settings,
-            noise: self.noise,
-        }
-    }
-
-    /// Transform the LayeredNoise to used normed (the default).
-    pub fn normed(self) -> LayeredBuilder<Normed<f32>, W, N> {
-        LayeredBuilder {
-            result_settings: Normed::default(),
-            weight_settings: self.weight_settings,
-            noise: self.noise,
-        }
-    }
-
     /// Adds an octave layer to the layered noise
     /// It takes a closure that provides a [`NoiseBuilder`] and expects a new one.
     pub fn octave_with<N2: Unnest, F: FnOnce(NoiseBuilder<()>) -> NoiseBuilder<N2>>(

--- a/src/layering.rs
+++ b/src/layering.rs
@@ -984,7 +984,7 @@ impl SampleDerivative<f32> for SmoothDerivativeContribution {
     fn sample_with_derivative_unchecked(&self, t: f32) -> WithDerivative<f32> {
         WithDerivative {
             value: bevy_math::ops::exp(-t),
-            derivative: bevy_math::ops::exp(-t) * -1.0,
+            derivative: -bevy_math::ops::exp(-t),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,14 @@ pub mod math_noise;
 pub mod misc_noise;
 pub mod prelude;
 pub mod rng;
+pub mod builder;
 
 use bevy_math::VectorSpace;
 use rng::NoiseRng;
+
+use crate::prelude::{
+        Masked, SNormToUNorm, Scaled, UNormToSNorm
+    };
 
 /// Represents a simple noise function with an input `I` and an output.
 ///
@@ -37,6 +42,14 @@ impl<I, T0: NoiseFunction<I>> NoiseFunction<I> for (T0,) {
     #[inline]
     fn evaluate(&self, input: I, seeds: &mut NoiseRng) -> Self::Output {
         self.0.evaluate(input, seeds)
+    }
+}
+
+impl<I> NoiseFunction<I> for () {
+    type Output = I;
+    #[inline]
+    fn evaluate(&self, input: I, _seeds: &mut NoiseRng) -> Self::Output {
+        input
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 )]
 #![doc = include_str!("../README.md")]
 
+pub mod builder;
 pub mod cell_noise;
 pub mod cells;
 pub mod curves;
@@ -14,14 +15,11 @@ pub mod math_noise;
 pub mod misc_noise;
 pub mod prelude;
 pub mod rng;
-pub mod builder;
 
 use bevy_math::VectorSpace;
 use rng::NoiseRng;
 
-use crate::prelude::{
-        Masked, SNormToUNorm, Scaled, UNormToSNorm
-    };
+use crate::prelude::{Masked, SNormToUNorm, Scaled, UNormToSNorm};
 
 /// Represents a simple noise function with an input `I` and an output.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,6 @@ pub mod rng;
 use bevy_math::VectorSpace;
 use rng::NoiseRng;
 
-use crate::prelude::{Masked, SNormToUNorm, Scaled, UNormToSNorm};
-
 /// Represents a simple noise function with an input `I` and an output.
 ///
 /// This is the powerhouse of this library.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,6 +17,7 @@ pub use crate::{
     math_noise::{Billow, PingPong, SNormToUNorm, UNormToSNorm},
     misc_noise::{Masked, Offset, RandomElements, RemapCurve, Scaled, SelfMasked, Translated},
     rng::{Random, SNorm, UNorm},
+    builder::*
 };
 
 /// Contains type aliases for common noise types.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,6 +3,7 @@
 pub use crate::{
     DynamicConfigurableSampleable, DynamicSampleable, Noise, NoiseFunction, Sampleable,
     SampleableFor, ScalableNoise, SeedableNoise,
+    builder::*,
     cell_noise::{
         BlendCellGradients, BlendCellValues, DistanceBlend, MixCellGradients, MixCellValues,
         PerCell, PerCellPointDistances, QuickGradients, SimplecticBlend, WorleyLeastDistance,
@@ -17,7 +18,6 @@ pub use crate::{
     math_noise::{Billow, PingPong, SNormToUNorm, UNormToSNorm},
     misc_noise::{Masked, Offset, RandomElements, RemapCurve, Scaled, SelfMasked, Translated},
     rng::{Random, SNorm, UNorm},
-    builder::*
 };
 
 /// Contains type aliases for common noise types.


### PR DESCRIPTION
This implements a builder pattern for Noise, as mentioned in #72 .

The `NoiseBuilder` (and associated `LayeredBuilder`) both have an inner type to represent the current noise, and all methods consume the builder and return a new `NoiseBuilder` object with a different type. 

The final noise produced with `.get_noise` and similar methods should be exactly the same as what would have been written by hand (meaning, fully typed). 

I don't see how we could have a dyn-compatible builder trait, which would enable full reflection. I don't think full reflection without performance overhead is really possible ? But I might be wrong. 

The documentation is very hasty right now, it needs to be rewritten. 