### PR TITLE
Bevy 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,52 +1,52 @@
 [package]
-name = "noiz"
-version = "0.3.0"
-edition = "2024"
-license = "MIT OR Apache-2.0"
-keywords = ["noise", "bevy", "math", "graphics", "random"]
+authors = ["Elliott Pierce"]
 categories = [
-  "no-std::no-alloc",
-  "no-std",
-  "mathematics",
   "game-development",
   "graphics",
+  "mathematics",
+  "no-std",
+  "no-std::no-alloc",
 ]
+description = "A simple, configurable, blazingly fast noise library built for and with Bevy."
+documentation = "https://docs.rs/noiz"
+edition = "2024"
+homepage = "https://github.com/ElliottjPierce/noiz"
+keywords = ["bevy", "graphics", "math", "noise", "random"]
+license = "MIT OR Apache-2.0"
+name = "noiz"
 readme = "README.md"
 repository = "https://github.com/ElliottjPierce/noiz"
-homepage = "https://github.com/ElliottjPierce/noiz"
-documentation = "https://docs.rs/noiz"
-authors = ["Elliott Pierce"]
-description = "A simple, configurable, blazingly fast noise library built for and with Bevy."
+version = "0.3.0"
 
 [dependencies]
-bevy_math = { version = "0.17", default-features = false, features = ["curve"] }
-bevy_reflect = { version = "0.17", default-features = false, features = [
+bevy_math = { default-features = false, features = ["curve"], version = "0.17" }
+bevy_reflect = { default-features = false, features = [
   "glam",
-], optional = true }
-serde = { version = "1", default-features = false, features = [
+], optional = true, version = "0.17" }
+serde = { default-features = false, features = [
   "derive",
-], optional = true }
+], optional = true, version = "1" }
 
 [dev-dependencies]
 # for examples
 bevy = "0.17"
 
 # For benches
-criterion = "0.5"
+criterion      = "0.5"
 fastnoise-lite = "1.1"
-noise = "0.9"
-libnoise = "1.1"
+libnoise       = "1.1"
+noise          = "0.9"
 
 [features]
-default = ["std", "bevy_reflect", "serialize"]
+default = ["bevy_reflect", "serialize", "std"]
 
-std = ["bevy_math/std", "bevy_reflect?/std", "serde?/std"]
-libm = ["bevy_math/libm"]
+libm       = ["bevy_math/libm"]
 nostd-libm = ["bevy_math/nostd-libm"]
+std        = ["bevy_math/std", "bevy_reflect?/std", "serde?/std"]
 
-serialize = ["dep:serde", "bevy_math/serialize"]
 bevy_reflect = ["dep:bevy_reflect"]
-debug = []
+debug        = []
+serialize    = ["bevy_math/serialize", "dep:serde"]
 
 [profile.dev]
 opt-level = 3
@@ -61,44 +61,44 @@ lto = "fat"
 codegen-units = 1
 # Disable incremental compilation for maximum optimization
 incremental = false
-opt-level = 3
+opt-level   = 3
 
 [build]
 rustflags = ["-O"]
 
 
 [lints.clippy]
-doc_markdown = "warn"
-manual_let_else = "warn"
-match_same_arms = "warn"
+doc_markdown                       = "warn"
+manual_let_else                    = "warn"
+match_same_arms                    = "warn"
+needless_lifetimes                 = "allow"
+nonstandard_macro_braces           = "warn"
 redundant_closure_for_method_calls = "warn"
-redundant_else = "warn"
-semicolon_if_nothing_returned = "warn"
-type_complexity = "allow"
-undocumented_unsafe_blocks = "warn"
-unwrap_or_default = "warn"
-needless_lifetimes = "allow"
-too_many_arguments = "allow"
-nonstandard_macro_braces = "warn"
+redundant_else                     = "warn"
+semicolon_if_nothing_returned      = "warn"
+too_many_arguments                 = "allow"
+type_complexity                    = "allow"
+undocumented_unsafe_blocks         = "warn"
+unwrap_or_default                  = "warn"
 
-ptr_as_ptr = "warn"
+ptr_as_ptr         = "warn"
 ptr_cast_constness = "warn"
-ref_as_ptr = "warn"
+ref_as_ptr         = "warn"
 
 too_long_first_doc_paragraph = "allow"
 
-std_instead_of_core = "warn"
-std_instead_of_alloc = "warn"
 alloc_instead_of_core = "warn"
+std_instead_of_alloc  = "warn"
+std_instead_of_core   = "warn"
 
-allow_attributes = "warn"
+allow_attributes                = "warn"
 allow_attributes_without_reason = "warn"
 
 [lints.rust]
-missing_docs = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs_dep)'] }
+missing_docs           = "warn"
+unexpected_cfgs        = { check-cfg = ['cfg(docsrs_dep)'], level = "warn" }
 unsafe_op_in_unsafe_fn = "warn"
-unused_qualifications = "warn"
+unused_qualifications  = "warn"
 
 [[example]]
 name = "show_noise"
@@ -117,6 +117,6 @@ name = "heightmap"
 path = "examples/heightmap.rs"
 
 [[bench]]
-name = "compare"
-path = "benches/compare/main.rs"
 harness = false
+name    = "compare"
+path    = "benches/compare/main.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde = { default-features = false, features = [
 bevy = "0.18"
 
 # For benches
-criterion      = "0.5"
+criterion      = "0.8"
 fastnoise-lite = "1.1"
 libnoise       = "1.1"
 noise          = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,17 +19,17 @@ repository = "https://github.com/ElliottjPierce/noiz"
 version = "0.3.0"
 
 [dependencies]
-bevy_math = { default-features = false, features = ["curve"], version = "0.17" }
+bevy_math = { default-features = false, features = ["curve"], version = "0.18" }
 bevy_reflect = { default-features = false, features = [
   "glam",
-], optional = true, version = "0.17" }
+], optional = true, version = "0.18" }
 serde = { default-features = false, features = [
   "derive",
 ], optional = true, version = "1" }
 
 [dev-dependencies]
 # for examples
-bevy = "0.17"
+bevy = "0.18"
 
 # For benches
 criterion      = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,6 @@ codegen-units = 1
 incremental = false
 opt-level   = 3
 
-[build]
-rustflags = ["-O"]
-
 
 [lints.clippy]
 doc_markdown                       = "warn"

--- a/benches/compare/fastnoise_lite.rs
+++ b/benches/compare/fastnoise_lite.rs
@@ -88,7 +88,7 @@ macro_rules! benches_nD {
         });
 
         fn fbm_perlin(group: &mut BenchmarkGroup<WallTime>, octaves: i32) {
-            let octaves = black_box(octaves);
+            let octaves = ::core::hint::black_box(octaves);
             group.bench_function(format!("perlin fbm {octaves} octaves"), |bencher| {
                 bencher.iter(|| {
                     let mut noise = FastNoiseLite::new();
@@ -104,7 +104,7 @@ macro_rules! benches_nD {
         }
 
         fn fbm_simplex(group: &mut BenchmarkGroup<WallTime>, octaves: i32) {
-            let octaves = black_box(octaves);
+            let octaves = ::core::hint::black_box(octaves);
             group.bench_function(format!("simplex fbm {octaves} octaves"), |bencher| {
                 bencher.iter(|| {
                     let mut noise = FastNoiseLite::new();
@@ -120,7 +120,7 @@ macro_rules! benches_nD {
         }
 
         fn fbm_value(group: &mut BenchmarkGroup<WallTime>, octaves: i32) {
-            let octaves = black_box(octaves);
+            let octaves = ::core::hint::black_box(octaves);
             group.bench_function(format!("value fbm {octaves} octaves"), |bencher| {
                 bencher.iter(|| {
                     let mut noise = FastNoiseLite::new();

--- a/benches/compare/libnoise.rs
+++ b/benches/compare/libnoise.rs
@@ -95,7 +95,7 @@ macro_rules! benches_nD {
         });
 
         fn fbm_perlin(group: &mut BenchmarkGroup<WallTime>, octaves: u32) {
-            let octaves = black_box(octaves);
+            let octaves = ::core::hint::black_box(octaves);
             group.bench_function(format!("perlin fbm {octaves} octaves"), |bencher| {
                 bencher.iter(|| {
                     let noise = Fbm::<$d, Perlin<$d>>::new(
@@ -111,7 +111,7 @@ macro_rules! benches_nD {
         }
 
         fn fbm_simplex(group: &mut BenchmarkGroup<WallTime>, octaves: u32) {
-            let octaves = black_box(octaves);
+            let octaves = ::core::hint::black_box(octaves);
             group.bench_function(format!("simplex fbm {octaves} octaves"), |bencher| {
                 bencher.iter(|| {
                     let noise = Fbm::<$d, Simplex<$d>>::new(
@@ -127,7 +127,7 @@ macro_rules! benches_nD {
         }
 
         fn fbm_value(group: &mut BenchmarkGroup<WallTime>, octaves: u32) {
-            let octaves = black_box(octaves);
+            let octaves = ::core::hint::black_box(octaves);
             group.bench_function(format!("value fbm {octaves} octaves"), |bencher| {
                 bencher.iter(|| {
                     let noise = Fbm::<$d, Value<$d>>::new(

--- a/benches/compare/main.rs
+++ b/benches/compare/main.rs
@@ -1,4 +1,4 @@
-//! Benches this noise lib compared to others.
+// Benches this noise lib compared to others.
 #![expect(
     missing_docs,
     reason = "Its a benchmark and cirterion macros don't add docs."

--- a/benches/compare/noise.rs
+++ b/benches/compare/noise.rs
@@ -86,7 +86,7 @@ macro_rules! benches_nD {
         });
 
         fn fbm_perlin(group: &mut BenchmarkGroup<WallTime>, octaves: usize) {
-            let octaves = black_box(octaves);
+            let octaves = ::core::hint::black_box(octaves);
             group.bench_function(format!("perlin fbm {octaves} octaves"), |bencher| {
                 bencher.iter(|| {
                     let mut noise = Fbm::<Perlin>::new(Perlin::DEFAULT_SEED);
@@ -110,7 +110,7 @@ macro_rules! benches_nD {
         }
 
         fn fbm_simplex(group: &mut BenchmarkGroup<WallTime>, octaves: usize) {
-            let octaves = black_box(octaves);
+            let octaves = ::core::hint::black_box(octaves);
             group.bench_function(format!("simplex fbm {octaves} octaves"), |bencher| {
                 bencher.iter(|| {
                     let mut noise = Fbm::<Simplex>::new(Simplex::DEFAULT_SEED);
@@ -134,7 +134,7 @@ macro_rules! benches_nD {
         }
 
         fn fbm_value(group: &mut BenchmarkGroup<WallTime>, octaves: usize) {
-            let octaves = black_box(octaves);
+            let octaves = ::core::hint::black_box(octaves);
             group.bench_function(format!("value fbm {octaves} octaves"), |bencher| {
                 bencher.iter(|| {
                     let mut noise = Fbm::<Value>::new(Perlin::DEFAULT_SEED);

--- a/benches/compare/noiz.rs
+++ b/benches/compare/noiz.rs
@@ -122,7 +122,7 @@ macro_rules! benches_nD {
         });
 
         fn fbm_perlin(group: &mut BenchmarkGroup<WallTime>, octaves: u32) {
-            let octaves = black_box(octaves);
+            let octaves = ::core::hint::black_box(octaves);
             group.bench_function(format!("perlin fbm {octaves} octaves"), |bencher| {
                 bencher.iter(|| {
                     let noise = Noise::<
@@ -148,7 +148,7 @@ macro_rules! benches_nD {
         }
 
         fn fbm_simplex(group: &mut BenchmarkGroup<WallTime>, octaves: u32) {
-            let octaves = black_box(octaves);
+            let octaves = ::core::hint::black_box(octaves);
             group.bench_function(format!("simplex fbm {octaves} octaves"), |bencher| {
                 bencher.iter(|| {
                     let noise = Noise::<
@@ -180,7 +180,7 @@ macro_rules! benches_nD {
         }
 
         fn fbm_value(group: &mut BenchmarkGroup<WallTime>, octaves: u32) {
-            let octaves = black_box(octaves);
+            let octaves = ::core::hint::black_box(octaves);
             group.bench_function(format!("value fbm {octaves} octaves"), |bencher| {
                 bencher.iter(|| {
                     let noise = Noise::<
@@ -219,7 +219,7 @@ pub fn benches(c: &mut Criterion) {
             let noise =
                 Noise::<MixCellValues<OrthoGrid, Smoothstep, Random<UNorm, f32>>>::default();
             let mut res = 0.0;
-            let ocraves = black_box(8u32);
+            let ocraves = ::core::hint::black_box(8u32);
             for x in 0..SIZE_2D {
                 for y in 0..SIZE_2D {
                     let mut loc = Vec2::new(x as f32, y as f32) / 32.0;

--- a/book.toml
+++ b/book.toml
@@ -1,8 +1,8 @@
 [book]
-authors = ["Elliott Pierce"]
+authors  = ["Elliott Pierce"]
 language = "en"
-src = "book/src"
-title = "Noiz Book"
+src      = "book/src"
+title    = "Noiz Book"
 
 [build]
 build-dir = "book/build"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,3 @@
-newline_style = "Unix"
+newline_style            = "Unix"
 use_field_init_shorthand = true
-use_try_shorthand = true
+use_try_shorthand        = true

--- a/typos.toml
+++ b/typos.toml
@@ -1,8 +1,8 @@
 [files]
 extend-exclude = [
-  "*.pbxproj", # metadata file
-  "*.patch",   # Automatically generated files that should not be manually modified.
   "*.bin",     # Binary files
+  "*.patch",   # Automatically generated files that should not be manually modified.
+  "*.pbxproj", # metadata file
   ".git/",     # Version control files
 ]
 ignore-hidden = false
@@ -13,8 +13,8 @@ LOD = "LOD" # Level of detail
 
 # Match a Whole Word - Case Sensitive
 [default.extend-identifiers]
+Pn  = "Pn"
 ser = "ser" # ron::ser - Serializer
-Pn = "Pn"
 
 [default]
 locale = "en-us"


### PR DESCRIPTION
Just your regular bevy update with some other maintenance commits. The other stuff is:

- formatting of `toml` files
- fixing some lints
- removing a deprecated section from the `Cargo.toml` file