### PR TITLE
Removed video link timestamp in book

### DIFF
--- a/book/src/more-info/learning-resources.md
+++ b/book/src/more-info/learning-resources.md
@@ -4,7 +4,7 @@ This is a list of places that teach how noise actually works mathematically.
 This background can be helpful for debugging any artifacting, etc, that may appear.
 
 - [This](https://iquilezles.org/articles/) website covers lots of cool math and some noise implementations.
-- [This](https://www.youtube.com/watch?v=DxUY42r_6Cg&t=619s) video visually explains value and perlin noise.
+- [This](https://www.youtube.com/watch?v=DxUY42r_6Cg) video visually explains value and perlin noise.
 - [This](https://muugumuugu.github.io/bOOkshelF/generative%20art/simplexnoise.pdf) paper explains simplex noise.
 
 This list is not at all exhaustive but hopefully provides enough context to get you started if you're curious.

--- a/book/src/quick-start/smooth-noise.md
+++ b/book/src/quick-start/smooth-noise.md
@@ -47,7 +47,7 @@ One way you might think of is to blur the lines between the squares.
 That's values noise!
 
 Basically, instead of picking a value for each domain cell, pick one for each corner of the domain cell, and mix those values together across the cell.
-If that didn't make sense, see a visual explanation [here](https://www.youtube.com/watch?v=DxUY42r_6Cg&t=619s), which covers both value and perlin noise; more on perlin in a bit.
+If that didn't make sense, see a visual explanation [here](https://www.youtube.com/watch?v=DxUY42r_6Cg), which covers both value and perlin noise; more on perlin in a bit.
 This is called [bilinear interpolation](https://en.wikipedia.org/wiki/Bilinear_interpolation).
 In noiz, we call this mixing, as it is generalized for squares, cubes, and hyper cubes.
 
@@ -102,7 +102,7 @@ It's just a bunch of blurry squares!
 That's where perlin noise comes in!
 Instead of mixing *random* values over a domain cell, source those values partly from the sample location and partly from a random unit vector.
 That probably won't make sense at first (and that's ok).
-If you want a visual explanation, see [here](https://www.youtube.com/watch?v=DxUY42r_6Cg&t=619s) again.
+If you want a visual explanation, see [here](https://www.youtube.com/watch?v=DxUY42r_6Cg) again.
 Ultimately, since the sample location has more effect, this adds lots more shapes to the noise.
 Here's how this works in noiz:
 


### PR DESCRIPTION
In the smooth noise section of the book, both links to Acerola's video on Perlin noise specified a timestamp of 619 seconds, which started the video at a section unrelated to the text around each link. Assuming this was a mistake, this PR removes the timestamp so the video starts at the beginning when following the link.

Edit: Found another instance of the 619 timestamp in the learning-resources page and fixed that one too.